### PR TITLE
Creates dim_address table and refactors staging tables names

### DIFF
--- a/models/intermediate/int_address__enriched.sql
+++ b/models/intermediate/int_address__enriched.sql
@@ -1,0 +1,28 @@
+with 
+    -- Importing model from staging
+    stg_erp__address as (
+        select * 
+        from {{ ref("stg_erp__address") }}
+    )
+    , stg_erp__stateprovince as (
+        select *
+        from {{ ref("stg_erp__stateprovince") }}
+    )
+    , stg_erp__countryregion as (
+        select * 
+        from {{ref("stg_erp__countryregion")}}
+    )
+    -- Joinning tables
+    , joined as (
+        select 
+            stg_erp__address.address_pk
+            , stg_erp__address.addressline1
+            , stg_erp__address.addressline2
+            , stg_erp__address.city_name
+            , stg_erp__stateprovince.state_name
+            , stg_erp__countryregion.country_name
+        from stg_erp__address
+        left join stg_erp__stateprovince on stg_erp__address.stateprovince_fk = stg_erp__stateprovince.stateprovince_pk
+        left join stg_erp__countryregion on stg_erp__stateprovince.countryregion_fk = stg_erp__countryregion.countryregion_pk
+    )
+    select * from joined

--- a/models/marts/dim_address.sql
+++ b/models/marts/dim_address.sql
@@ -1,0 +1,7 @@
+with 
+    int_address as (
+        select *
+        from {{ref("int_address__enriched")}}
+    )
+
+select * from int_address

--- a/models/marts/dim_address.yml
+++ b/models/marts/dim_address.yml
@@ -1,0 +1,10 @@
+models:
+  - name: dim_address
+    description: >
+      asdasdasd
+    columns:
+      - name: address_pk
+        description: Unique identifier for each customer.
+        tests:
+          - unique
+          - not_null

--- a/models/staging/erp/stg_erp__address.sql
+++ b/models/staging/erp/stg_erp__address.sql
@@ -1,5 +1,5 @@
 with 
-    source_person_address as (
+    source_address as (
     select * 
     from {{ source('erp', 'person_address') }}
 ),
@@ -10,8 +10,8 @@ renamed as (
         , cast(stateprovinceid as int) as stateprovince_fk
         , cast(addressline1 as varchar) as addressline1
         , cast(addressline2 as varchar) as addressline2
-        , cast(city as varchar) as city
-    from source_person_address
+        , cast(city as varchar) as city_name
+    from source_address
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__countryregion.sql
+++ b/models/staging/erp/stg_erp__countryregion.sql
@@ -1,5 +1,5 @@
 with 
-    source_person_countryregion as (
+    source_countryregion as (
     select * 
     from {{ source('erp', 'person_countryregion') }}
 ),
@@ -7,8 +7,8 @@ with
 renamed as (
     select
         cast(countryregioncode as varchar) as countryregion_pk
-        , cast(name as varchar) as name
-    from source_person_countryregion
+        , cast(name as varchar) as country_name
+    from source_countryregion
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__creditcard.sql
+++ b/models/staging/erp/stg_erp__creditcard.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_creditcard as (
+    source_creditcard as (
     select * 
     from {{ source('erp', 'sales_creditcard') }}
 ),
@@ -12,7 +12,7 @@ renamed as (
         , cast(expmonth as int) as expmonth
         , cast(expyear as int) as expyear
 
-    from source_sales_creditcard
+    from source_creditcard
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__customer.sql
+++ b/models/staging/erp/stg_erp__customer.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_customer as (
+    source_customer as (
     select * 
     from {{ source('erp', 'sales_customer') }}
 ),
@@ -10,7 +10,7 @@ renamed as (
         , cast(personid as int) as person_fk
         , cast(storeid as int) as store_fk
         , cast(territoryid as int) as territory_fk
-    from source_sales_customer
+    from source_customer
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__person.sql
+++ b/models/staging/erp/stg_erp__person.sql
@@ -1,5 +1,5 @@
 with 
-    source_person_person as (
+    source_person as (
     select * 
     from {{ source('erp', 'person_person') }}
 ),
@@ -13,7 +13,7 @@ renamed as (
         , cast(lastname as varchar) as lastname
         , cast(emailpromotion as int) as emailpromotion
         , cast(additionalcontactinfo as varchar) as additionalcontactinfo
-    from source_person_person
+    from source_person
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__product.sql
+++ b/models/staging/erp/stg_erp__product.sql
@@ -1,5 +1,5 @@
 with 
-    source_production_product as (
+    source_product as (
     select * 
     from {{ source('erp', 'production_product') }}
 ),
@@ -16,7 +16,7 @@ renamed as (
         , cast(name as varchar) as product_name
         , cast(productnumber as varchar) as product_number
         , cast(productline as varchar) as productline
-    from source_production_product
+    from source_product
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__salesorderdetail.sql
+++ b/models/staging/erp/stg_erp__salesorderdetail.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_salesorderdetail as (
+    source_salesorderdetail as (
     select * 
     from {{ source('erp', 'sales_salesorderdetail') }}
 ),
@@ -13,7 +13,7 @@ renamed as (
         , cast(unitprice as numeric(18,4)) as unitprice
         , cast(unitpricediscount as numeric(18,2)) as unitpricediscount
         , cast(orderqty as int) as orderqty
-    from source_sales_salesorderdetail
+    from source_salesorderdetail
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__salesorderheader.sql
+++ b/models/staging/erp/stg_erp__salesorderheader.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_salesorderheader as (
+    source_salesorderheader as (
     select * 
     from {{ source('erp', 'sales_salesorderheader') }}
 
@@ -25,7 +25,7 @@ renamed as (
         , cast(status as int) as status
         , cast(onlineorderflag as boolean) as onlineorderflag
         , cast(purchaseordernumber as varchar) as purchaseordernumber
-    from source_sales_salesorderheader
+    from source_salesorderheader
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__salesorderheadersalesreason.sql
+++ b/models/staging/erp/stg_erp__salesorderheadersalesreason.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_salesorderheadersalesreason as (
+    source_salesorderheadersalesreason as (
     select * 
     from {{ source('erp', 'sales_salesorderheadersalesreason') }}
 ),
@@ -8,7 +8,7 @@ renamed as (
     select
         {{ dbt_utils.generate_surrogate_key(['salesorderid', 'salesreasonid']) }} as sales_order_header_reason_sk
         , cast(salesreasonid as int) as salesreason_fk
-    from source_sales_salesorderheadersalesreason
+    from source_salesorderheadersalesreason
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__salesreason.sql
+++ b/models/staging/erp/stg_erp__salesreason.sql
@@ -1,5 +1,5 @@
 with 
-    source_sales_salesreason as (
+    source_salesreason as (
     select * 
     from {{ source('erp', 'sales_salesreason') }}
 ),
@@ -9,7 +9,7 @@ renamed as (
         cast(salesreasonid as int) as salesreason_pk
         , cast(name as varchar) as name
         , cast(reasontype as varchar) as reasontype
-    from source_sales_salesreason
+    from source_salesreason
 )
 
 select * from renamed

--- a/models/staging/erp/stg_erp__stateprovince.sql
+++ b/models/staging/erp/stg_erp__stateprovince.sql
@@ -1,5 +1,5 @@
 with 
-    person_stateprovince as (
+    source_stateprovince as (
     select * 
     from {{ source('erp', 'person_stateprovince') }}
 ),
@@ -7,12 +7,12 @@ with
 renamed as (
     select
         cast(stateprovinceid as int) as stateprovince_pk
+        , cast(countryregioncode as varchar) as countryregion_fk
         , cast(territoryid as int) as territory_fk
         , cast(stateprovincecode as varchar) as stateprovincecode
-        , cast(countryregioncode as varchar) as countryregioncode
         , cast(isonlystateprovinceflag as boolean) as isonlystateprovinceflag
-        , cast(name as varchar) as name
-    from person_stateprovince
+        , cast(name as varchar) as state_name
+    from source_stateprovince
 )
 
 select * from renamed


### PR DESCRIPTION
The dim_address dimensional table is built through the intermediate model int_address__enriched, which performs joins between the staging tables stg_erp__address, stg_erp__stateprovince, and stg_erp__countryregion.

To improve naming clarity and simplify references across the project, all staging tables have had their original schema prefixes removed during the modeling process.