### PR TITLE
Creates dim_salesreason table and a bridge table to connect dim_sales reason with the fact_sales

### DIFF
--- a/models/intermediate/int_sales_order_reason_bridge__cleaned.sql
+++ b/models/intermediate/int_sales_order_reason_bridge__cleaned.sql
@@ -1,0 +1,16 @@
+with
+    --Importing model from staging
+    stg_erp__salesorderheadersalesreason as (
+        select *
+        from {{ref("stg_erp__salesorderheadersalesreason")}}
+    )
+    , cleaned as (
+        select
+            stg_erp__salesorderheadersalesreason.sales_order_header_reason_sk
+            , stg_erp__salesorderheadersalesreason.salesorder_fk
+            , stg_erp__salesorderheadersalesreason.salesreason_fk
+        from stg_erp__salesorderheadersalesreason
+    )
+
+    select * from cleaned
+    

--- a/models/marts/bridge_dim_salesreason_fact.sql
+++ b/models/marts/bridge_dim_salesreason_fact.sql
@@ -1,0 +1,7 @@
+with
+    int_sales_order_reason_bridge as (
+        select *
+        from {{ref("int_sales_order_reason_bridge__cleaned")}}
+    )
+
+select * from int_sales_order_reason_bridge

--- a/models/marts/bridge_dim_salesreason_fact.yml
+++ b/models/marts/bridge_dim_salesreason_fact.yml
@@ -1,0 +1,10 @@
+models:
+  - name: bridge_dim_salesreason_fact
+    description: >
+      asdasdasd
+    columns:
+      - name: sales_order_header_reason_sk
+        description: Unique identifier for each customer.
+        tests:
+          - unique
+          - not_null

--- a/models/marts/dim_salesreason.sql
+++ b/models/marts/dim_salesreason.sql
@@ -1,0 +1,7 @@
+with
+    int_salesreason as (
+        select *
+        from {{ref("stg_erp__salesreason")}}
+    )
+
+select * from int_salesreason

--- a/models/marts/dim_salesreason.yml
+++ b/models/marts/dim_salesreason.yml
@@ -1,0 +1,10 @@
+models:
+  - name: dim_salesreason
+    description: >
+      asdasdasd
+    columns:
+      - name: salesreason_pk
+        description: Unique identifier for each customer.
+        tests:
+          - unique
+          - not_null

--- a/models/staging/erp/stg_erp__salesorderheadersalesreason.sql
+++ b/models/staging/erp/stg_erp__salesorderheadersalesreason.sql
@@ -2,11 +2,11 @@ with
     source_salesorderheadersalesreason as (
     select * 
     from {{ source('erp', 'sales_salesorderheadersalesreason') }}
-),
-
-renamed as (
+)
+, renamed as (
     select
         {{ dbt_utils.generate_surrogate_key(['salesorderid', 'salesreasonid']) }} as sales_order_header_reason_sk
+        , cast(source_salesorderheadersalesreason.salesorderid as int) as salesorder_fk
         , cast(salesreasonid as int) as salesreason_fk
     from source_salesorderheadersalesreason
 )

--- a/models/staging/erp/stg_erp__salesreason.sql
+++ b/models/staging/erp/stg_erp__salesreason.sql
@@ -3,11 +3,10 @@ with
     select * 
     from {{ source('erp', 'sales_salesreason') }}
 ),
-
 renamed as (
     select
         cast(salesreasonid as int) as salesreason_pk
-        , cast(name as varchar) as name
+        , cast(name as varchar) as reason_name
         , cast(reasontype as varchar) as reasontype
     from source_salesreason
 )


### PR DESCRIPTION
Creates dim_salesreason and bridge_dim_salesreason_fact Tables

The dim_salesreason table contains sales reason details.
The bridge_dim_salesreason_fact table serves as an intermediary to connect dim_salesreason with fact_sales, reflecting a many-to-many relationship present in the source system via a secondary mapping table.