### PR TITLE
Creates fact_sales table and a custom test for this table

### DIFF
--- a/models/intermediate/int_fact__metrics.sql
+++ b/models/intermediate/int_fact__metrics.sql
@@ -1,0 +1,74 @@
+with
+    --Importing models from staging
+    orderdetails as (
+        select *
+        from {{ref("stg_erp__salesorderdetail")}}
+    )
+    , orderheader as (
+        select *
+        from {{ref("stg_erp__salesorderheader")}}
+    )
+    -- Joining tables
+    , joined as (
+        select 
+            orderdetails.order_item_sk
+            , orderdetails.order_fk
+            , orderdetails.product_fk
+            , orderdetails.specialoffer_fk
+            , orderheader.salesperson_fk
+            , orderheader.customer_fk
+            , orderheader.territory_fk
+            , orderheader.billtoaddress_fk
+            , orderheader.shiptoaddress_fk
+            , orderheader.shipmethod_fk
+            , orderheader.creditcard_fk
+            , orderheader.orderdate
+            , orderheader.duedate
+            , orderheader.shipdate
+            , orderdetails.unitprice
+            , orderdetails.unitpricediscount
+            , orderdetails.orderqty
+            , orderheader.subtotal
+            , orderheader.taxamt
+            , orderheader.freight
+            , orderheader.totaldue
+            , orderheader.orderheader_number
+            , orderheader.onlineorderflag
+        from orderdetails
+        inner join orderheader on orderdetails.order_fk = orderheader.orderheader_pk
+    )
+    -- Enrichment and treatment of nulls
+    , metrics as (
+        select 
+            order_item_sk
+            , order_fk
+            , product_fk
+            , specialoffer_fk
+            , salesperson_fk
+            , customer_fk
+            , territory_fk
+            , billtoaddress_fk
+            , shiptoaddress_fk
+            , shipmethod_fk
+            , creditcard_fk
+            , orderdate
+            , duedate
+            , shipdate
+            , unitprice
+            , unitpricediscount
+            , orderqty
+            , unitprice * orderqty as gross_total
+            , unitprice * orderqty - (1 - unitpricediscount) as net_total
+            , subtotal
+            , taxamt
+            , freight
+            , cast(
+                freight / count(*) over (partition by orderheader_number) 
+                as numeric(18,2)
+            ) as freight_allocated
+            , totaldue
+            , onlineorderflag
+        from joined
+    )
+
+select * from metrics

--- a/models/marts/fact_sales.sql
+++ b/models/marts/fact_sales.sql
@@ -1,0 +1,7 @@
+with
+    int_fact as (
+        select *
+        from {{ref("int_fact__metrics")}}
+    )
+
+select * from int_fact

--- a/models/marts/fact_sales.yml
+++ b/models/marts/fact_sales.yml
@@ -1,0 +1,10 @@
+models:
+  - name: fact_sales
+    description: >
+      ggdsfaadasd
+    columns:
+      - name: order_item_sk
+        description: Unique identifier for each customer.
+        tests:
+          - unique
+          - not_null

--- a/models/staging/erp/stg_erp__salesorderdetail.sql
+++ b/models/staging/erp/stg_erp__salesorderdetail.sql
@@ -6,8 +6,8 @@ with
 
 renamed as (
     select
-        {{ dbt_utils.generate_surrogate_key(['salesorderid', 'salesorderdetailid']) }} as sales_order_item_sk
-        , cast(salesorderid as int) as salesorder_fk
+        {{ dbt_utils.generate_surrogate_key(['salesorderid', 'salesorderdetailid']) }} as order_item_sk
+        , cast(salesorderid as int) as order_fk
         , cast(productid as int) as product_fk
         , cast(specialofferid as int) as specialoffer_fk
         , cast(unitprice as numeric(18,4)) as unitprice

--- a/models/staging/erp/stg_erp__salesorderheader.sql
+++ b/models/staging/erp/stg_erp__salesorderheader.sql
@@ -7,7 +7,7 @@ with
 
 renamed as (
     select
-        cast(salesorderid as int) as sales_salesorderheader_pk
+        cast(salesorderid as int) as orderheader_pk
         , cast(salespersonid as int) as salesperson_fk
         , cast(customerid as int) as customer_fk
         , cast(territoryid as int) as territory_fk
@@ -22,9 +22,9 @@ renamed as (
         , cast(taxamt as numeric(18,2)) as taxamt
         , cast(freight as numeric(18,2)) as freight
         , cast(totaldue as numeric(18,2)) as totaldue
+        , cast(salesorderid as int) as orderheader_number
         , cast(status as int) as status
         , cast(onlineorderflag as boolean) as onlineorderflag
-        , cast(purchaseordernumber as varchar) as purchaseordernumber
     from source_salesorderheader
 )
 

--- a/tests/tst_total_sales_2011.sql
+++ b/tests/tst_total_sales_2011.sql
@@ -1,0 +1,14 @@
+/*
+    This test ensures that the gross sales for years between 1996 and 1998 match
+    the audited accounting value: R$ 12.646.112,16
+*/
+
+with sales_2011 as (
+    select sum(gross_total) as total
+    from {{ ref('int_fact__metrics') }}
+    where orderdate between '2011-01-01' and '2011-12-31'
+)
+
+select *
+from sales_2011
+where total not between 12646112.12 and 12646112.20


### PR DESCRIPTION
Creates the fact_sales table based on the int_fact__metrics model, which joins the salesorderheader and salesorderdetail tables to calculate relevant sales metrics. Additionally, it includes a test to validate that the gross_total (calculated as unitprice * orderqty) for sales made in 2011 equals $12,646,112.16.

This model also renames certain columns for consistency and clarity, and removes unused columns that are not needed in the marts layer.